### PR TITLE
Sync: pi integration improvements, worktree fixes, and more

### DIFF
--- a/.emacs.d/emacs.org
+++ b/.emacs.d/emacs.org
@@ -398,14 +398,7 @@ Consult provides more mini-buffer search functionality
   :hook
   (embark-collect-mode . embark-consult-preview-minor-mode))
 
-(use-package consult-flycheck
-  :bind (:map flycheck-command-map
-              ("!" . consult-flycheck)
-              :map prog-mode-map
-              ("<f2>" . flycheck-list-errors))
-  ;; If flycheck idle change delay is too short, then it overwrites the helpful
-  ;; messages about how to call elisp functions, etc.
-  :config (setq flycheck-idle-change-delay 15))
+
 
 #+end_src
 ** Movement
@@ -589,20 +582,6 @@ Hydra is useful for doing lots of things in succession.
      "Movement"
      (("f" yas-next-field "forward field" :exit nil)
       ("b" yas-prev-field "previous field" :exit nil))))
-  (pretty-hydra-define hydra-flycheck ()
-    ("Movement"
-     (("n" flymake-goto-next-error "next error")
-      ("p" flymake-goto-prev-error "previous error")
-      ("d" flymake-goto-diagnostic "diagnostic")
-      ("<" flycheck-previous-error "previous flycheck error")
-      (">" flycheck-next-error "next flycheck error")
-      ("l" flycheck-list-errors "list")
-      ("." consult-flymake))
-     "Display"
-     (("." flymake-show-diagnostic "show diagnostic")
-      ("B" flymake-show-diagnostics-buffer "diagnostics buffers"))
-     "Misc"
-     (("=" hydra-all/body "back" :exit t))))
   ;; notmuch is too specialized to be set up here, it varies from machine to
   ;; machine. At some point I should break it down into the general &
   ;; specialized parts.
@@ -630,7 +609,6 @@ Hydra is useful for doing lots of things in succession.
      (("i" consult-imenu "imenu" :exit t)
       ("m" consult-mark "mark rings" :exit t)
       ("o" consult-multi-occur "occur" :exit t)
-      ("e" consult-flycheck "errors" :exit t)
       ("l" consult-goto-line "line" :exit t))
      "Other"
      (("r" consult-ripgrep "grep" :exit t)
@@ -652,7 +630,6 @@ Hydra is useful for doing lots of things in succession.
       ("y" hydra-yas/body "snippets" :exit t))
      "Movement"
      (("j" hydra-jumps/body "jumps" :exit t)
-      ("E" hydra-flycheck/body "errors" :exit t)
       ("G" deadgrep "grep" :exit t))
      "Misc"
      (("f" hydra-find/body "find" :exit t))))
@@ -747,8 +724,6 @@ Confession time: vi's killing up to a char is better than emacs, so let's change
 (use-package lsp-mode
   :config
   (setq lsp-warn-no-matched-clients nil)
-  :general
-  ("<f2>" 'lsp-ui-flycheck-list)
   :hook ((python-base-mode . lsp-mode)
          (go-mode . lsp-mode)
          (go-ts-mode . lsp-mode)))
@@ -767,7 +742,6 @@ Eglot is smaller, and I've had good success with it when it works.  However, now
                            ["flake8"]
                            :plugins (:pycodestyle (:enabled nil) :mccabe (:enabled nil) :pyflakes (:enabled nil) :flake8 (:enabled t)))))))
 
-(use-package flycheck-eglot)
 (use-package consult-eglot)
 (use-package consult-eglot-embark
   :config
@@ -812,51 +786,7 @@ Git gutter highlights changes to files.
     :diminish git-gutter-mode)
 #+END_SRC
 
-Flycheck will help check for all errors.  Taken from https://jamiecollinson.com/blog/my-emacs-config/#syntax-checking.
-#+BEGIN_SRC emacs-lisp
-(use-package flycheck
-  :custom
-  (flycheck-disabled-checkers '(emacs-lisp-checkdoc))
-  :config
-  (add-hook 'after-init-hook 'global-flycheck-mode)
-  (setq-default flycheck-highlighting-mode 'lines
-                ;; Wait before complaining so we don't step on useful help messages.
-                flycheck-idle-change-delay 3)
-  ;; Define fringe indicator / warning levels
-  (define-fringe-bitmap 'flycheck-fringe-bitmap-ball
-    (vector #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00011100
-            #b00111110
-            #b00111110
-            #b00111110
-            #b00011100
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000))
-  (flycheck-define-error-level 'error
-    :severity 2
-    :overlay-category 'flycheck-error-overlay
-    :fringe-bitmap 'flycheck-fringe-bitmap-ball
-    :fringe-face 'flycheck-fringe-error)
-  (flycheck-define-error-level 'warning
-    :severity 1
-    :overlay-category 'flycheck-warning-overlay
-    :fringe-bitmap 'flycheck-fringe-bitmap-ball
-    :fringe-face 'flycheck-fringe-warning)
-  (flycheck-define-error-level 'info
-    :severity 0
-    :overlay-category 'flycheck-info-overlay
-    :fringe-bitmap 'flycheck-fringe-bitmap-ball
-    :fringe-face 'flycheck-fringe-info))
-#+END_SRC
+
 *** Tree Sitter
 This gives emacs the power to interact with the AST.
 #+begin_src emacs-lisp
@@ -892,13 +822,11 @@ This gives emacs the power to interact with the AST.
 *** Markdown
 #+begin_src emacs-lisp
 (use-package markdown-mode)
-(use-package flymake-markdownlint)
 #+end_src
 
 *** YAML
 #+begin_src emacs-lisp
 (use-package yaml-mode)
-(use-package flycheck-yamllint)
 #+end_src
 *** Python
 Let's use treesit mode, which should already be available.
@@ -914,10 +842,6 @@ We also want type checking.
 #+begin_src emacs-lisp
 (use-package lsp-pyright
   :ensure t)
-;; setup flycheck
-(add-hook 'python-base-mode-hook (lambda ()
-                                   (flycheck-select-checker 'python-pyright)
-                                   (setq flycheck-disabled-checkers '(python-mypy python-pylint))))
 #+end_src
 **** venv management
 #+begin_src emacs-lisp
@@ -974,7 +898,7 @@ Combobulate is interesting, but not on an ELPA yet, so let's not install.
 #+end_src
 *** ELPA helpers
 #+begin_src emacs-lisp
-(use-package flycheck-package)
+
 #+end_src
 *** Copilot
 #+begin_src emacs-lisp
@@ -1030,8 +954,6 @@ various places.
   (add-hook 'ef-themes-post-load-hook
             #'ash/ef-themes-custom-faces))
 
-;; Selection of our default theme
-(ef-themes-select 'ef-day)
 #+END_SRC
 
 Make org prettier.
@@ -1110,7 +1032,23 @@ Also, I don't like wide buffers.
 
 #+begin_src emacs-lisp
 (use-package olivetti :ensure t
-  :hook ((text-mode prog-mode org-mode) . olivetti-mode))
+  :hook ((text-mode prog-mode org-mode) . olivetti-mode)
+  :config
+  (defun ash/olivetti-target-columns ()
+    "Return target column width for the current major mode, or nil."
+    (cond ((derived-mode-p 'python-mode 'python-ts-mode) 120)
+          ((derived-mode-p 'org-mode) 80)
+          (t nil)))
+
+  (defun ash/olivetti-adjust-scale ()
+    "Scale text so the target number of columns fills the window width."
+    (when-let ((target (and olivetti-mode (ash/olivetti-target-columns))))
+      (let* ((ratio (/ (float (window-pixel-width))
+                       (* target (frame-char-width))))
+             (level (/ (log ratio) (log text-scale-mode-step))))
+        (text-scale-set (min (max 0 (floor level)) 2)))))
+
+  (add-hook 'olivetti-mode-hook #'ash/olivetti-adjust-scale))
 #+end_src
 *** Dim other buffers
 #+begin_src emacs-lisp
@@ -1388,9 +1326,6 @@ Mermaid is a tool for drawing systems diagrams.
         (ekg-save-note (ekg-note-create :text text :mode (if org-mode 'org-mode 'text-mode)
                                         :tags `(,(ekg-tag-for-date) "log"))))))
 
-  (dolist (h '(ekg-capture-mode-hook ekg-edit-mode-hook ekg-notes-mode-hook))
-    (add-hook h (lambda ()
-                  (when (boundp 'flycheck-mode) (flycheck-mode -1)))))
   (add-to-list 'display-buffer-alist '("*EKG Capture.*\\*"
                                        (display-buffer-in-side-window)
                                        (side . right)
@@ -1441,6 +1376,7 @@ Also clocks into the org task."
                                    (string= (alist-get 'name tab) worktree-name))
                                  (funcall tab-bar-tabs-function))))
     (org-set-property "WORKTREE" worktree-name)
+    (org-todo "STARTED")
     (save-buffer)
     (if existing-tab
         ;; Switch to existing tab
@@ -1451,8 +1387,6 @@ Also clocks into the org task."
              (org-context (buffer-substring-no-properties
                            (org-entry-beginning-position)
                            (org-entry-end-position))))
-        ;; Set task to STARTED
-        (org-todo "STARTED")
         ;; Create worktree from main branch if it doesn't exist
         (unless (file-directory-p worktree-path)
           (let ((default-directory base-repo))
@@ -1472,16 +1406,18 @@ Also clocks into the org task."
         (tab-bar-new-tab)
         (tab-bar-rename-tab worktree-name)
         ;; Start agent shell in worktree
-        (run-at-time 1 nil
+        (run-at-time 1.5 nil
                      (lambda (path)
                        (let ((default-directory path))
                          (pi-coding-agent)))
                      worktree-path)
 
         ;; Store worktree info in buffer and send context
-        (run-at-time 1 nil
+        (run-at-time 2 nil
                      (lambda (path name org-id)
-                       (mapc (lambda (buf)
+                       (let ((default-directory path))
+                         (message "In lambda: agent buffers: %S" (mapcar #'buffer-name (ash/agent-buffers)))
+                         (mapc (lambda (buf)
                               (with-current-buffer buf
                                 (setq-local ash/agent-shell-worktree-path path)
                                 (setq-local ash/agent-shell-worktree-name name)
@@ -1489,7 +1425,7 @@ Also clocks into the org task."
                                 (when (string-match "input" (buffer-name buf))
                                   (insert (format "/do-org %s" org-id))
                                   (pi-coding-agent-send))))
-                             (ash/agent-buffers)))
+                             (ash/agent-buffers))))
                      worktree-path worktree-name org-id)))))
 
 (defun ash/agent-buffers ()
@@ -1513,6 +1449,7 @@ Also clocks into the org task."
     (mapc #'kill-buffer agent-buffers)
     ;; Remove worktree
     (let ((default-directory (expand-file-name "~/src/workspace")))
+      (message "Removing worktree at %s" worktree-path)
       (shell-command (format "git worktree remove %s"
                              (shell-quote-argument worktree-path)))
       ;; Delete the branch
@@ -1798,6 +1735,7 @@ Finally, set up tabs the way I like them, so everything has its place.
              tabspaces-open-or-create-project-and-workspace)
   :general
   ("s-b" 'project-switch-to-buffer)
+  ("s-T" 'tab-bar-select-tab-by-name)
   :custom
   (tabspaces-use-filtered-buffers-as-default t)
   (tabspaces-default-tab "main")

--- a/.emacs.d/emacs.org
+++ b/.emacs.d/emacs.org
@@ -725,7 +725,21 @@ Confession time: vi's killing up to a char is better than emacs, so let's change
 *** Magit
 #+begin_src emacs-lisp
 (use-package magit
-  :general ("C-x g" 'magit-status))
+ :general ("C-x g" 'ash/magit-status)
+  :config
+  (defun ash/magit-status ()
+    "Open Magit status for the current project."
+    (interactive)
+    (let ((project-root (or
+                         (let ((tab-src (format "~/src/%s"
+                                                (substring-no-properties
+                                                 (tabspaces--current-tab-name)))))
+                           (when (file-directory-p tab-src)
+                             tab-src))
+                         (project-root (or (project-current t)
+                                           (error "No project found in the current directory")))
+                         default-directory)))
+      (magit-status project-root))))
 #+end_src
 *** LSP variants
 **** LSP
@@ -1091,6 +1105,13 @@ Darkroom is a distraction-free experience.  It handles margins as well as font s
   :config
   (spacious-padding-mode 1))
 #+end_src
+
+Also, I don't like wide buffers.
+
+#+begin_src emacs-lisp
+(use-package olivetti :ensure t
+  :hook ((text-mode prog-mode org-mode) . olivetti-mode))
+#+end_src
 *** Dim other buffers
 #+begin_src emacs-lisp
 (use-package auto-dim-other-buffers
@@ -1378,6 +1399,154 @@ Mermaid is a tool for drawing systems diagrams.
                                        (window-parameters (no-delete-other-windows . t))))
   (setq ekg-llm-provider ash/llm-gemini))
 #+end_src
+** Agentic coding
+*** Agentic buffer management
+It's good to have agentic buffers readily available, doing something meaningful per tab.
+
+The way it works is that from org-mode we can clock in, start agentic flows that will decide on a name, add worktrees, add a new tab, and start our agentic code with my custom command to read from the currently clocked org task.
+#+begin_src emacs-lisp
+(defvar-local ash/agent-shell-worktree-path nil
+  "Buffer-local worktree path for this agent shell.")
+
+(defvar-local ash/agent-shell-worktree-name nil
+  "Buffer-local worktree name for this agent shell.")
+
+(defun ash/org-item-to-worktree-name ()
+  "Get a short worktree name from the current org item using LLM."
+  (let* ((heading (org-get-heading t t t t))
+         (response (llm-chat emacs-llm-default-provider
+                             (llm-make-chat-prompt
+                              (format "Create a short git branch name (2-4 words max, lowercase, hyphenated, no special characters) for this task: %s" heading)
+                              :response-format '(:type object
+                                                       :properties (:name (:type "string"))
+                                                       :required ["name"]))))
+         (parsed (json-parse-string response :object-type 'plist)))
+    (plist-get parsed :name)))
+
+(defun ash/org-code ()
+  "Start standard code agent shell for the current org item.
+
+This will also create a new git worktree.
+
+If a tab and buffer already exist for this item, switch to them instead.
+Also clocks into the org task."
+  (interactive)
+  (require 'org)
+  (require 'org-id)
+  (unless (derived-mode-p 'org-mode)
+    (user-error "Not in an org-mode buffer"))
+  (let* ((org-id (org-id-get-create t))
+         (worktree-name (ash/org-item-to-worktree-name))
+         (existing-tab (seq-find (lambda (tab)
+                                   (string= (alist-get 'name tab) worktree-name))
+                                 (funcall tab-bar-tabs-function))))
+    (org-set-property "WORKTREE" worktree-name)
+    (save-buffer)
+    (if existing-tab
+        ;; Switch to existing tab
+        (tab-bar-select-tab-by-name worktree-name)
+      ;; Create new worktree and tab
+      (let* ((base-repo (expand-file-name "~/src/workspace"))
+             (worktree-path (expand-file-name (format "../%s" worktree-name) base-repo))
+             (org-context (buffer-substring-no-properties
+                           (org-entry-beginning-position)
+                           (org-entry-end-position))))
+        ;; Set task to STARTED
+        (org-todo "STARTED")
+        ;; Create worktree from main branch if it doesn't exist
+        (unless (file-directory-p worktree-path)
+          (let ((default-directory base-repo))
+          (unless (zerop (shell-command
+                          (format "git worktree add -b ahyatt/%s %s main"
+                                  (shell-quote-argument worktree-name)
+                                  (shell-quote-argument worktree-path))))
+            (user-error "Failed to create worktree"))))
+        ;; Symlink .pi/git from base repo so the new worktree's pi
+        ;; session doesn't need to re-clone extensions on first start.
+        (let ((base-pi-git (expand-file-name ".pi/git" base-repo))
+              (wt-pi-git (expand-file-name ".pi/git" worktree-path)))
+          (when (and (file-directory-p base-pi-git)
+                     (not (file-exists-p wt-pi-git)))
+            (make-symbolic-link base-pi-git wt-pi-git)))
+        ;; Create tab and switch to it
+        (tab-bar-new-tab)
+        (tab-bar-rename-tab worktree-name)
+        ;; Start agent shell in worktree
+        (run-at-time 1 nil
+                     (lambda (path)
+                       (let ((default-directory path))
+                         (pi-coding-agent)))
+                     worktree-path)
+
+        ;; Store worktree info in buffer and send context
+        (run-at-time 1 nil
+                     (lambda (path name org-id)
+                       (mapc (lambda (buf)
+                              (with-current-buffer buf
+                                (setq-local ash/agent-shell-worktree-path path)
+                                (setq-local ash/agent-shell-worktree-name name)
+                                (goto-char (point-max))
+                                (when (string-match "input" (buffer-name buf))
+                                  (insert (format "/do-org %s" org-id))
+                                  (pi-coding-agent-send))))
+                             (ash/agent-buffers)))
+                     worktree-path worktree-name org-id)))))
+
+(defun ash/agent-buffers ()
+  "Get the current agent shell buffers, as a list."
+  (sort
+   (seq-filter (lambda (buf)
+                 (and (string-prefix-p "*pi-coding-agent" (buffer-name buf))
+                      (string-suffix-p
+                       (format "%s/*" (tabspaces--current-tab-name)) (buffer-name buf))))
+               (buffer-list))))
+
+(defun ash/agent-shell-finish-org ()
+  "Send /finish-org, remove worktree, and close tab."
+  (interactive)
+  (let* ((worktree-name (tabspaces--current-tab-name))
+         (worktree-path (format "~/src/%s" worktree-name))
+         (agent-buffers (ash/agent-buffers)))
+    (unless worktree-path
+      (user-error "No worktree associated with this agent shell"))
+    ;; Kill the agent shell buffer
+    (mapc #'kill-buffer agent-buffers)
+    ;; Remove worktree
+    (let ((default-directory (expand-file-name "~/src/workspace")))
+      (shell-command (format "git worktree remove %s"
+                             (shell-quote-argument worktree-path)))
+      ;; Delete the branch
+      (shell-command (format "git branch -D ahyatt/%s"
+                             (shell-quote-argument worktree-name))))
+    ;; Close the correct tab
+    (tab-bar-close-tab-by-name worktree-name)))
+#+end_src
+*** Pi
+
+Currently this is good and has a good emacs package
+#+begin_src emacs-lisp
+(use-package pi-coding-agent
+  :ensure t
+  :init (defalias 'pi 'pi-coding-agent)
+  :config
+  (defun ash/pi-coding-agent-two-windows ()
+    "Display pi-coding-agent input and chat buffers in two windows.
+Input buffer on top, chat buffer on bottom."
+    (interactive)
+    (let ((agent-buffers (ash/agent-buffers)))
+      (cl-flet ((process-buffer (buf)
+                  (switch-to-buffer buf)
+                  (goto-char (point-max))
+                  (when (string-match-p "input" (buffer-name))
+                    (set-window-text-height nil 4))))
+        (delete-other-windows)
+        (process-buffer (car agent-buffers))
+        (dolist (buf (cdr agent-buffers))
+          (split-window-below)
+          (process-buffer buf)))))
+  :bind ("s-i" . ash/pi-coding-agent-two-windows))
+#+end_src
+***
 * Tangling-related
 
 We need to add some functions to make dealing with this file easier.
@@ -1523,7 +1692,7 @@ those customizations.
      '("y" . meow-save)
      '("Y" . meow-sync-grab)
      '("z" . meow-pop-selection)
-     '("'" . )
+     '("'" . repeat-fu-execute)
      '("<escape>" . ignore)))
   (require 'meow-cheatsheet-layout)
   (meow-setup)

--- a/.emacs.d/emacs.org
+++ b/.emacs.d/emacs.org
@@ -1441,7 +1441,7 @@ Also clocks into the org task."
   "Send /finish-org, remove worktree, and close tab."
   (interactive)
   (let* ((worktree-name (tabspaces--current-tab-name))
-         (worktree-path (format "~/src/%s" worktree-name))
+         (worktree-path (expand-file-name (format "~/src/%s" worktree-name)))
          (agent-buffers (ash/agent-buffers)))
     (unless worktree-path
       (user-error "No worktree associated with this agent shell"))

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -1123,7 +1123,7 @@ Also clocks into the org task."
   "Send /finish-org, remove worktree, and close tab."
   (interactive)
   (let* ((worktree-name (tabspaces--current-tab-name))
-         (worktree-path (format "~/src/%s" worktree-name))
+         (worktree-path (expand-file-name (format "~/src/%s" worktree-name)))
          (agent-buffers (ash/agent-buffers)))
     (unless worktree-path
       (user-error "No worktree associated with this agent shell"))

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -289,15 +289,6 @@
   :hook
   (embark-collect-mode . embark-consult-preview-minor-mode))
 
-(use-package consult-flycheck
-  :bind (:map flycheck-command-map
-              ("!" . consult-flycheck)
-              :map prog-mode-map
-              ("<f2>" . flycheck-list-errors))
-  ;; If flycheck idle change delay is too short, then it overwrites the helpful
-  ;; messages about how to call elisp functions, etc.
-  :config (setq flycheck-idle-change-delay 15))
-
 (use-package winum
   :config (winum-mode 1)
   :general
@@ -459,20 +450,6 @@
      "Movement"
      (("f" yas-next-field "forward field" :exit nil)
       ("b" yas-prev-field "previous field" :exit nil))))
-  (pretty-hydra-define hydra-flycheck ()
-    ("Movement"
-     (("n" flymake-goto-next-error "next error")
-      ("p" flymake-goto-prev-error "previous error")
-      ("d" flymake-goto-diagnostic "diagnostic")
-      ("<" flycheck-previous-error "previous flycheck error")
-      (">" flycheck-next-error "next flycheck error")
-      ("l" flycheck-list-errors "list")
-      ("." consult-flymake))
-     "Display"
-     (("." flymake-show-diagnostic "show diagnostic")
-      ("B" flymake-show-diagnostics-buffer "diagnostics buffers"))
-     "Misc"
-     (("=" hydra-all/body "back" :exit t))))
   ;; notmuch is too specialized to be set up here, it varies from machine to
   ;; machine. At some point I should break it down into the general &
   ;; specialized parts.
@@ -500,7 +477,6 @@
      (("i" consult-imenu "imenu" :exit t)
       ("m" consult-mark "mark rings" :exit t)
       ("o" consult-multi-occur "occur" :exit t)
-      ("e" consult-flycheck "errors" :exit t)
       ("l" consult-goto-line "line" :exit t))
      "Other"
      (("r" consult-ripgrep "grep" :exit t)
@@ -522,7 +498,6 @@
       ("y" hydra-yas/body "snippets" :exit t))
      "Movement"
      (("j" hydra-jumps/body "jumps" :exit t)
-      ("E" hydra-flycheck/body "errors" :exit t)
       ("G" deadgrep "grep" :exit t))
      "Misc"
      (("f" hydra-find/body "find" :exit t))))
@@ -586,8 +561,6 @@
 (use-package lsp-mode
   :config
   (setq lsp-warn-no-matched-clients nil)
-  :general
-  ("<f2>" 'lsp-ui-flycheck-list)
   :hook ((python-base-mode . lsp-mode)
          (go-mode . lsp-mode)
          (go-ts-mode . lsp-mode)))
@@ -602,7 +575,6 @@
                            ["flake8"]
                            :plugins (:pycodestyle (:enabled nil) :mccabe (:enabled nil) :pyflakes (:enabled nil) :flake8 (:enabled t)))))))
 
-(use-package flycheck-eglot)
 (use-package consult-eglot)
 (use-package consult-eglot-embark
   :config
@@ -632,49 +604,6 @@
   :config
   (global-git-gutter-mode 't)
   :diminish git-gutter-mode)
-
-(use-package flycheck
-  :custom
-  (flycheck-disabled-checkers '(emacs-lisp-checkdoc))
-  :config
-  (add-hook 'after-init-hook 'global-flycheck-mode)
-  (setq-default flycheck-highlighting-mode 'lines
-                ;; Wait before complaining so we don't step on useful help messages.
-                flycheck-idle-change-delay 3)
-  ;; Define fringe indicator / warning levels
-  (define-fringe-bitmap 'flycheck-fringe-bitmap-ball
-    (vector #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00011100
-            #b00111110
-            #b00111110
-            #b00111110
-            #b00011100
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000
-            #b00000000))
-  (flycheck-define-error-level 'error
-    :severity 2
-    :overlay-category 'flycheck-error-overlay
-    :fringe-bitmap 'flycheck-fringe-bitmap-ball
-    :fringe-face 'flycheck-fringe-error)
-  (flycheck-define-error-level 'warning
-    :severity 1
-    :overlay-category 'flycheck-warning-overlay
-    :fringe-bitmap 'flycheck-fringe-bitmap-ball
-    :fringe-face 'flycheck-fringe-warning)
-  (flycheck-define-error-level 'info
-    :severity 0
-    :overlay-category 'flycheck-info-overlay
-    :fringe-bitmap 'flycheck-fringe-bitmap-ball
-    :fringe-face 'flycheck-fringe-info))
 
 (use-package tree-sitter
   :config
@@ -706,10 +635,8 @@
 (use-package tree-sitter-langs)
 
 (use-package markdown-mode)
-(use-package flymake-markdownlint)
 
 (use-package yaml-mode)
-(use-package flycheck-yamllint)
 
 ;; Assuming python-ts-mode is installed
 ;; Add a hook to automatically use python-ts-mode for Python files
@@ -718,10 +645,6 @@
 
 (use-package lsp-pyright
   :ensure t)
-;; setup flycheck
-(add-hook 'python-base-mode-hook (lambda ()
-                                   (flycheck-select-checker 'python-pyright)
-                                   (setq flycheck-disabled-checkers '(python-mypy python-pylint))))
 
 (use-package virtualenvwrapper
   :ensure t
@@ -768,7 +691,7 @@
                                              default-directory)))
                   (apply orig-fun args)))))
 
-(use-package flycheck-package)
+
 
 (use-package copilot
   :vc (:url "https://github.com/copilot-emacs/copilot.el"
@@ -808,9 +731,6 @@
        `(telephone-line-projectile ((,c :foreground ,accent-1))))))
   (add-hook 'ef-themes-post-load-hook
             #'ash/ef-themes-custom-faces))
-
-;; Selection of our default theme
-(ef-themes-select 'ef-day)
 
 (use-package org-bullets
   :init (add-hook 'org-mode-hook #'org-bullets-mode))
@@ -861,7 +781,23 @@
   (spacious-padding-mode 1))
 
 (use-package olivetti :ensure t
-  :hook ((text-mode prog-mode org-mode) . olivetti-mode))
+  :hook ((text-mode prog-mode org-mode) . olivetti-mode)
+  :config
+  (defun ash/olivetti-target-columns ()
+    "Return target column width for the current major mode, or nil."
+    (cond ((derived-mode-p 'python-mode 'python-ts-mode) 120)
+          ((derived-mode-p 'org-mode) 80)
+          (t nil)))
+
+  (defun ash/olivetti-adjust-scale ()
+    "Scale text so the target number of columns fills the window width."
+    (when-let ((target (and olivetti-mode (ash/olivetti-target-columns))))
+      (let* ((ratio (/ (float (window-pixel-width))
+                       (* target (frame-char-width))))
+             (level (/ (log ratio) (log text-scale-mode-step))))
+        (text-scale-set (min (max 0 (floor level)) 2)))))
+
+  (add-hook 'olivetti-mode-hook #'ash/olivetti-adjust-scale))
 
 (use-package auto-dim-other-buffers
   :ensure t
@@ -1078,9 +1014,6 @@
         (ekg-save-note (ekg-note-create :text text :mode (if org-mode 'org-mode 'text-mode)
                                         :tags `(,(ekg-tag-for-date) "log"))))))
 
-  (dolist (h '(ekg-capture-mode-hook ekg-edit-mode-hook ekg-notes-mode-hook))
-    (add-hook h (lambda ()
-                  (when (boundp 'flycheck-mode) (flycheck-mode -1)))))
   (add-to-list 'display-buffer-alist '("*EKG Capture.*\\*"
                                        (display-buffer-in-side-window)
                                        (side . right)
@@ -1125,6 +1058,7 @@ Also clocks into the org task."
                                    (string= (alist-get 'name tab) worktree-name))
                                  (funcall tab-bar-tabs-function))))
     (org-set-property "WORKTREE" worktree-name)
+    (org-todo "STARTED")
     (save-buffer)
     (if existing-tab
         ;; Switch to existing tab
@@ -1135,8 +1069,6 @@ Also clocks into the org task."
              (org-context (buffer-substring-no-properties
                            (org-entry-beginning-position)
                            (org-entry-end-position))))
-        ;; Set task to STARTED
-        (org-todo "STARTED")
         ;; Create worktree from main branch if it doesn't exist
         (unless (file-directory-p worktree-path)
           (let ((default-directory base-repo))
@@ -1156,16 +1088,18 @@ Also clocks into the org task."
         (tab-bar-new-tab)
         (tab-bar-rename-tab worktree-name)
         ;; Start agent shell in worktree
-        (run-at-time 1 nil
+        (run-at-time 1.5 nil
                      (lambda (path)
                        (let ((default-directory path))
                          (pi-coding-agent)))
                      worktree-path)
 
         ;; Store worktree info in buffer and send context
-        (run-at-time 1 nil
+        (run-at-time 2 nil
                      (lambda (path name org-id)
-                       (mapc (lambda (buf)
+                       (let ((default-directory path))
+                         (message "In lambda: agent buffers: %S" (mapcar #'buffer-name (ash/agent-buffers)))
+                         (mapc (lambda (buf)
                               (with-current-buffer buf
                                 (setq-local ash/agent-shell-worktree-path path)
                                 (setq-local ash/agent-shell-worktree-name name)
@@ -1173,7 +1107,7 @@ Also clocks into the org task."
                                 (when (string-match "input" (buffer-name buf))
                                   (insert (format "/do-org %s" org-id))
                                   (pi-coding-agent-send))))
-                             (ash/agent-buffers)))
+                             (ash/agent-buffers))))
                      worktree-path worktree-name org-id)))))
 
 (defun ash/agent-buffers ()
@@ -1197,6 +1131,7 @@ Also clocks into the org task."
     (mapc #'kill-buffer agent-buffers)
     ;; Remove worktree
     (let ((default-directory (expand-file-name "~/src/workspace")))
+      (message "Removing worktree at %s" worktree-path)
       (shell-command (format "git worktree remove %s"
                              (shell-quote-argument worktree-path)))
       ;; Delete the branch
@@ -1438,6 +1373,7 @@ This has to be done as a string to handle 64-bit or larger ints."
              tabspaces-open-or-create-project-and-workspace)
   :general
   ("s-b" 'project-switch-to-buffer)
+  ("s-T" 'tab-bar-select-tab-by-name)
   :custom
   (tabspaces-use-filtered-buffers-as-default t)
   (tabspaces-default-tab "main")

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -567,7 +567,21 @@
       (delete-trailing-whitespace))))
 
 (use-package magit
-  :general ("C-x g" 'magit-status))
+ :general ("C-x g" 'ash/magit-status)
+  :config
+  (defun ash/magit-status ()
+    "Open Magit status for the current project."
+    (interactive)
+    (let ((project-root (or
+                         (let ((tab-src (format "~/src/%s"
+                                                (substring-no-properties
+                                                 (tabspaces--current-tab-name)))))
+                           (when (file-directory-p tab-src)
+                             tab-src))
+                         (project-root (or (project-current t)
+                                           (error "No project found in the current directory")))
+                         default-directory)))
+      (magit-status project-root))))
 
 (use-package lsp-mode
   :config
@@ -846,6 +860,9 @@
   :config
   (spacious-padding-mode 1))
 
+(use-package olivetti :ensure t
+  :hook ((text-mode prog-mode org-mode) . olivetti-mode))
+
 (use-package auto-dim-other-buffers
   :ensure t
   :config
@@ -1072,6 +1089,143 @@
                                        (window-parameters (no-delete-other-windows . t))))
   (setq ekg-llm-provider ash/llm-gemini))
 
+(defvar-local ash/agent-shell-worktree-path nil
+  "Buffer-local worktree path for this agent shell.")
+
+(defvar-local ash/agent-shell-worktree-name nil
+  "Buffer-local worktree name for this agent shell.")
+
+(defun ash/org-item-to-worktree-name ()
+  "Get a short worktree name from the current org item using LLM."
+  (let* ((heading (org-get-heading t t t t))
+         (response (llm-chat emacs-llm-default-provider
+                             (llm-make-chat-prompt
+                              (format "Create a short git branch name (2-4 words max, lowercase, hyphenated, no special characters) for this task: %s" heading)
+                              :response-format '(:type object
+                                                       :properties (:name (:type "string"))
+                                                       :required ["name"]))))
+         (parsed (json-parse-string response :object-type 'plist)))
+    (plist-get parsed :name)))
+
+(defun ash/org-code ()
+  "Start standard code agent shell for the current org item.
+
+This will also create a new git worktree.
+
+If a tab and buffer already exist for this item, switch to them instead.
+Also clocks into the org task."
+  (interactive)
+  (require 'org)
+  (require 'org-id)
+  (unless (derived-mode-p 'org-mode)
+    (user-error "Not in an org-mode buffer"))
+  (let* ((org-id (org-id-get-create t))
+         (worktree-name (ash/org-item-to-worktree-name))
+         (existing-tab (seq-find (lambda (tab)
+                                   (string= (alist-get 'name tab) worktree-name))
+                                 (funcall tab-bar-tabs-function))))
+    (org-set-property "WORKTREE" worktree-name)
+    (save-buffer)
+    (if existing-tab
+        ;; Switch to existing tab
+        (tab-bar-select-tab-by-name worktree-name)
+      ;; Create new worktree and tab
+      (let* ((base-repo (expand-file-name "~/src/workspace"))
+             (worktree-path (expand-file-name (format "../%s" worktree-name) base-repo))
+             (org-context (buffer-substring-no-properties
+                           (org-entry-beginning-position)
+                           (org-entry-end-position))))
+        ;; Set task to STARTED
+        (org-todo "STARTED")
+        ;; Create worktree from main branch if it doesn't exist
+        (unless (file-directory-p worktree-path)
+          (let ((default-directory base-repo))
+          (unless (zerop (shell-command
+                          (format "git worktree add -b ahyatt/%s %s main"
+                                  (shell-quote-argument worktree-name)
+                                  (shell-quote-argument worktree-path))))
+            (user-error "Failed to create worktree"))))
+        ;; Symlink .pi/git from base repo so the new worktree's pi
+        ;; session doesn't need to re-clone extensions on first start.
+        (let ((base-pi-git (expand-file-name ".pi/git" base-repo))
+              (wt-pi-git (expand-file-name ".pi/git" worktree-path)))
+          (when (and (file-directory-p base-pi-git)
+                     (not (file-exists-p wt-pi-git)))
+            (make-symbolic-link base-pi-git wt-pi-git)))
+        ;; Create tab and switch to it
+        (tab-bar-new-tab)
+        (tab-bar-rename-tab worktree-name)
+        ;; Start agent shell in worktree
+        (run-at-time 1 nil
+                     (lambda (path)
+                       (let ((default-directory path))
+                         (pi-coding-agent)))
+                     worktree-path)
+
+        ;; Store worktree info in buffer and send context
+        (run-at-time 1 nil
+                     (lambda (path name org-id)
+                       (mapc (lambda (buf)
+                              (with-current-buffer buf
+                                (setq-local ash/agent-shell-worktree-path path)
+                                (setq-local ash/agent-shell-worktree-name name)
+                                (goto-char (point-max))
+                                (when (string-match "input" (buffer-name buf))
+                                  (insert (format "/do-org %s" org-id))
+                                  (pi-coding-agent-send))))
+                             (ash/agent-buffers)))
+                     worktree-path worktree-name org-id)))))
+
+(defun ash/agent-buffers ()
+  "Get the current agent shell buffers, as a list."
+  (sort
+   (seq-filter (lambda (buf)
+                 (and (string-prefix-p "*pi-coding-agent" (buffer-name buf))
+                      (string-suffix-p
+                       (format "%s/*" (tabspaces--current-tab-name)) (buffer-name buf))))
+               (buffer-list))))
+
+(defun ash/agent-shell-finish-org ()
+  "Send /finish-org, remove worktree, and close tab."
+  (interactive)
+  (let* ((worktree-name (tabspaces--current-tab-name))
+         (worktree-path (format "~/src/%s" worktree-name))
+         (agent-buffers (ash/agent-buffers)))
+    (unless worktree-path
+      (user-error "No worktree associated with this agent shell"))
+    ;; Kill the agent shell buffer
+    (mapc #'kill-buffer agent-buffers)
+    ;; Remove worktree
+    (let ((default-directory (expand-file-name "~/src/workspace")))
+      (shell-command (format "git worktree remove %s"
+                             (shell-quote-argument worktree-path)))
+      ;; Delete the branch
+      (shell-command (format "git branch -D ahyatt/%s"
+                             (shell-quote-argument worktree-name))))
+    ;; Close the correct tab
+    (tab-bar-close-tab-by-name worktree-name)))
+
+(use-package pi-coding-agent
+  :ensure t
+  :init (defalias 'pi 'pi-coding-agent)
+  :config
+  (defun ash/pi-coding-agent-two-windows ()
+    "Display pi-coding-agent input and chat buffers in two windows.
+Input buffer on top, chat buffer on bottom."
+    (interactive)
+    (let ((agent-buffers (ash/agent-buffers)))
+      (cl-flet ((process-buffer (buf)
+                  (switch-to-buffer buf)
+                  (goto-char (point-max))
+                  (when (string-match-p "input" (buffer-name))
+                    (set-window-text-height nil 4))))
+        (delete-other-windows)
+        (process-buffer (car agent-buffers))
+        (dolist (buf (cdr agent-buffers))
+          (split-window-below)
+          (process-buffer buf)))))
+  :bind ("s-i" . ash/pi-coding-agent-two-windows))
+
 (defun ash/tangle-config ()
   "Tangle the config file to a standard config file."
   (interactive nil org-mode)
@@ -1191,7 +1345,7 @@ This has to be done as a string to handle 64-bit or larger ints."
      '("y" . meow-save)
      '("Y" . meow-sync-grab)
      '("z" . meow-pop-selection)
-     '("'" . )
+     '("'" . repeat-fu-execute)
      '("<escape>" . ignore)))
   (require 'meow-cheatsheet-layout)
   (meow-setup)


### PR DESCRIPTION
Changes since last sync:

- Fix worktree path: use expand-file-name so git can find the worktree (~ not expanded by git)
- Fix pi integration, remove flycheck
- Fix ash/org-code, add olivetti
- Add org-todo STARTED when starting a worktree task
- Symlink .pi/git from base repo for new worktrees
- Updated pi-coding-agent run-at-time flow with /do-org support
- Use ahyatt/ prefix for branch deletion (matches creation)
- Add message logging for worktree removal
- Add s-T keybinding for tab-bar-select-tab-by-name (keep C-x b for tabspaces too)
- Add Forge package for magit
- Improved ash/magit-status with substring-no-properties and better error handling